### PR TITLE
Don't always call wrapdocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,4 @@ ENV LC_ALL en_US.UTF-8
 
 VOLUME /scratch
 
-RUN sed -i 's/exec\ bash/sleep\ 1\ \&\&\ exec\ "$@"/' /usr/local/bin/wrapdocker
-
-ENTRYPOINT [ "/usr/local/bin/wrapdocker" ]
-
-CMD ["/bin/bash"]
+CMD ["/usr/local/bin/wrapdocker"]


### PR DESCRIPTION
Being that dind is not the norm for most builds, it is better to not call
wrapdocker by default because it requires --privileged
